### PR TITLE
Patch Serializer representaiton to drop queryset

### DIFF
--- a/rest_framework/utils/representation.py
+++ b/rest_framework/utils/representation.py
@@ -52,6 +52,8 @@ def smart_repr(value):
 
 def field_repr(field, force_many=False):
     kwargs = field._kwargs
+    kwargs.pop('queryset', None)
+
     if force_many:
         kwargs = kwargs.copy()
         kwargs['many'] = True


### PR DESCRIPTION
The Field(queryset=[trigger a DB lookup to render this] logic
is dubious, and might be causing DB deadlocks.

Tear it out to see if this resolves the issue.
